### PR TITLE
Test-modals : 간단한 모달 형태 확인용 컴포넌트 구현

### DIFF
--- a/src/components/Modals/AlertModal.jsx
+++ b/src/components/Modals/AlertModal.jsx
@@ -1,11 +1,9 @@
 import styled from 'styled-components';
 
-const AlertModal = ({ isOpen, handleModal }) => {
+const AlertModal = ({ isAlertModalOpen }) => {
   return (
-    <StdModal $isOpen={isOpen}>
-      <div>
-        <button onClick={handleModal}>x</button>알림
-      </div>
+    <StdModal $isAlertModalOpen={isAlertModalOpen}>
+      <div>알림</div>
       <div>내용11</div>
     </StdModal>
   );
@@ -14,10 +12,10 @@ const AlertModal = ({ isOpen, handleModal }) => {
 export default AlertModal;
 
 const StdModal = styled.div`
-  display: ${(props) => (props.$isOpen ? 'block' : 'none')};
-  width: 100px;
+  display: ${(props) => (props.$isAlertModalOpen ? 'block' : 'none')};
+  flex: 1 1 auto;
   height: 80%;
-  background-color: gray;
-  position: fixed;
-  left: auto;
+  background-color: #c2fff8;
+  position: relative;
+  transform: translate(100%, -100%);
 `;

--- a/src/components/Modals/AlertModal.jsx
+++ b/src/components/Modals/AlertModal.jsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+const AlertModal = ({ isOpen, handleModal }) => {
+  return (
+    <StdModal $isOpen={isOpen}>
+      <div>
+        <button onClick={handleModal}>x</button>알림
+      </div>
+      <div>내용</div>
+    </StdModal>
+  );
+};
+
+export default AlertModal;
+
+const StdModal = styled.div`
+  display: ${(props) => (props.$isOpen ? 'block' : 'none')};
+  width: 100px;
+  height: 80%;
+  background-color: gray;
+  position: fixed;
+  left: auto;
+`;

--- a/src/components/Modals/SettingModal.jsx
+++ b/src/components/Modals/SettingModal.jsx
@@ -1,17 +1,17 @@
 import styled from 'styled-components';
 
-const AlertModal = ({ isOpen, handleModal }) => {
+const SettingModal = ({ isOpen, handleModal }) => {
   return (
     <StdModal $isOpen={isOpen}>
       <div>
         <button onClick={handleModal}>x</button>알림
       </div>
-      <div>내용11</div>
+      <div>내용22</div>
     </StdModal>
   );
 };
 
-export default AlertModal;
+export default SettingModal;
 
 const StdModal = styled.div`
   display: ${(props) => (props.$isOpen ? 'block' : 'none')};

--- a/src/components/Modals/SettingModal.jsx
+++ b/src/components/Modals/SettingModal.jsx
@@ -1,11 +1,9 @@
 import styled from 'styled-components';
 
-const SettingModal = ({ isOpen, handleModal }) => {
+const SettingModal = ({ isOpen }) => {
   return (
     <StdModal $isOpen={isOpen}>
-      <div>
-        <button onClick={handleModal}>x</button>알림
-      </div>
+      <div>세팅</div>
       <div>내용22</div>
     </StdModal>
   );
@@ -15,9 +13,9 @@ export default SettingModal;
 
 const StdModal = styled.div`
   display: ${(props) => (props.$isOpen ? 'block' : 'none')};
-  width: 100px;
+  flex: 1 1 auto;
   height: 80%;
-  background-color: gray;
-  position: fixed;
-  left: auto;
+  background-color: #caefff;
+  position: relative;
+  transform: translate(100%, -100%);
 `;

--- a/src/components/Modals/StdModal.js
+++ b/src/components/Modals/StdModal.js
@@ -1,17 +1,14 @@
 import styled from 'styled-components';
 
-const AlertModal = ({ isOpen, handleModal }) => {
+const DefaultModal = ({ children }) => {
   return (
-    <StdModal $isOpen={isOpen}>
-      <div>
-        <button onClick={handleModal}>x</button>알림
-      </div>
-      <div>내용11</div>
-    </StdModal>
+    <>
+      <StdModal>{children}</StdModal>
+    </>
   );
 };
 
-export default AlertModal;
+export default DefaultModal;
 
 const StdModal = styled.div`
   display: ${(props) => (props.$isOpen ? 'block' : 'none')};

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { CopyPlus, Bookmark, BellRing, Settings } from 'lucide-react';
+import AlertModal from './Modals/AlertModal';
 
 const SideBar = () => {
   return (
@@ -15,7 +16,7 @@ const SideBar = () => {
           <Bookmark />
         </SideBarButton>
       </Link>
-      <SideBarButton>
+      <SideBarButton onClick={hadleModal}>
         <BellRing />
       </SideBarButton>
       <SideBarButton>

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -6,10 +6,27 @@ import AlertModal from '../components/Modals/AlertModal';
 import SettingModal from './Modals/SettingModal';
 
 const SideBar = () => {
+  // 세팅 열고닫기에 필요한 useState
   const [isModalOpen, setIsModalOpen] = useState(false);
+  // 알림 열고닫기에 필요한 useState
+  const [isAlertModalOpen, setIsAlertModalOpen] = useState(false);
+
+  // 세팅 모달 열고닫기
   const handleModal = () => {
+    if (isAlertModalOpen === true) {
+      setIsAlertModalOpen(false);
+    }
     setIsModalOpen(!isModalOpen);
   };
+
+  // 알림 모달 열고닫기
+  const handleAlertModal = () => {
+    if (isModalOpen === true) {
+      setIsModalOpen(false);
+    }
+    setIsAlertModalOpen(!isAlertModalOpen);
+  };
+
   return (
     <>
       <SideBarWrapper>
@@ -23,14 +40,14 @@ const SideBar = () => {
             <Bookmark />
           </SideBarButton>
         </Link>
-        <SideBarButton onClick={handleModal}>
+        <SideBarButton onClick={handleAlertModal}>
           <BellRing />
         </SideBarButton>
         <SideBarButton onClick={handleModal}>
           <Settings />
         </SideBarButton>
       </SideBarWrapper>
-      <AlertModal isOpen={isModalOpen} handleModal={handleModal} />
+      <AlertModal isAlertModalOpen={isAlertModalOpen} handleAlertModal={handleAlertModal} />
       <SettingModal isOpen={isModalOpen} handleModal={handleModal} />
     </>
   );

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -1,28 +1,38 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { CopyPlus, Bookmark, BellRing, Settings } from 'lucide-react';
-import AlertModal from './Modals/AlertModal';
+import { useState } from 'react';
+import AlertModal from '../components/Modals/AlertModal';
+import SettingModal from './Modals/SettingModal';
 
 const SideBar = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const handleModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
   return (
-    <SideBarWrapper>
-      <Link to="/add-feed">
-        <SideBarButton>
-          <CopyPlus />
+    <>
+      <SideBarWrapper>
+        <Link to="/add-feed">
+          <SideBarButton>
+            <CopyPlus />
+          </SideBarButton>
+        </Link>
+        <Link to="/bookmarks">
+          <SideBarButton>
+            <Bookmark />
+          </SideBarButton>
+        </Link>
+        <SideBarButton onClick={handleModal}>
+          <BellRing />
         </SideBarButton>
-      </Link>
-      <Link to="/bookmarks">
-        <SideBarButton>
-          <Bookmark />
+        <SideBarButton onClick={handleModal}>
+          <Settings />
         </SideBarButton>
-      </Link>
-      <SideBarButton onClick={hadleModal}>
-        <BellRing />
-      </SideBarButton>
-      <SideBarButton>
-        <Settings />
-      </SideBarButton>
-    </SideBarWrapper>
+      </SideBarWrapper>
+      <AlertModal isOpen={isModalOpen} handleModal={handleModal} />
+      <SettingModal isOpen={isModalOpen} handleModal={handleModal} />
+    </>
   );
 };
 


### PR DESCRIPTION
### 전체적인 요약 
기존 public-modal의 context 오류 상황으로 모달 구현 확인을 형태만 알 수 있도록 간단한 prop-drilling 형태 구현 


### 상세 내용 
1. components 폴더 내 Modals 생성 : AlertModal , SettingModal 
2. SideBar 컴포넌트에서 불러오기: isModalOpen 과 isAlertModalOpen 으로 모달 가시성 토글
3. handleModal (세팅 설정 모달 제어) 와 handleAlertModal(알림 모달 제어) 함수 설정 
4. 이미 열린 모달창이 있는 상태에서 다른 모달창을 열면 기존 모달창이 닫히는 로직 부여 

![화면 캡처 2025-02-15 144014](https://github.com/user-attachments/assets/89233012-131b-49dd-8a59-514e4cfbbc76)
![화면 캡처 2025-02-15 144055](https://github.com/user-attachments/assets/3a39932c-221e-4389-b9ba-0d652e70d1e9)

※ 홈페이지 높이 고정의 문제가 생긴 것으로 보임 