### PR TITLE
detail-page : query-string 통한 detail 페이지 전환과 간단한 구성

### DIFF
--- a/src/components/FeedList.jsx
+++ b/src/components/FeedList.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import MOCK_DATA from '../data/MOCK_DATA';
 import styled from 'styled-components';
 import { Heart, MessageCircle, Star } from 'lucide-react';
@@ -7,13 +8,15 @@ const FeedList = () => {
     <FeedListWrapper>
       {MOCK_DATA.map((Movie) => (
         <FeedListContent key={Movie.id}>
-          <FeedListContentTitle>{Movie.korean_name}</FeedListContentTitle>
-          <img src={Movie.img_url} alt="" />
-          <FeedListIcon>
-            <Heart />
-            <MessageCircle />
-            <Star />
-          </FeedListIcon>
+          <Link to={`/main/detail/${Movie.id}`}>
+            <FeedListContentTitle>{Movie.korean_name}</FeedListContentTitle>
+            <img src={Movie.img_url} alt="" />
+            <FeedListIcon>
+              <Heart />
+              <MessageCircle />
+              <Star />
+            </FeedListIcon>
+          </Link>
         </FeedListContent>
       ))}
     </FeedListWrapper>

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -24,8 +24,9 @@ const DetailPage = () => {
               <Bookmark />
             </StdBookmark>
           </StdFeedHeader>
+          <div>{movie.korean_name}</div>
           <div className="hash-tag">
-            <span fontSize={'1em'}>#해시태그</span>
+            <span>#해시태그</span>
           </div>
           <div className="star">★★★</div>
           <ul className="comment-list">
@@ -58,8 +59,9 @@ const StdFeedDetail = styled.div`
   min-height: 50%;
   position: relative;
   background-color: orange;
-  padding: 5%;
+  margin: 5%;
   border-radius: 10%;
+  overflow: hidden;
 `;
 
 const StdProfile = styled.img`
@@ -80,6 +82,7 @@ const StdImageContainer = styled.div`
   min-height: 50%;
   background-color: green;
   border-radius: 10%;
+  overflow: hidden;
 `;
 
 const StdImage = styled.img`
@@ -89,7 +92,10 @@ const StdImage = styled.img`
 const StdFeedHeader = styled.div`
   display: flex;
   justify-content: center;
-  max-height: fit-content;
-  flex: 3 1 0;
+  width: 100%;
+  max-height: min-content;
+  flex: 3 0 0;
   gap: 20%;
+  background-color: palegreen;
+  border-bottom: dashed 2px;
 `;

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -1,4 +1,4 @@
-import { useLocation, useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import MOCK_DATA from '../data/MOCK_DATA';
 
@@ -9,10 +9,10 @@ const DetailPage = () => {
 
   return (
     <StdFeedContainer className="feed-container">
-      <div>
-        <StdImage src={movie.img_url} />
-      </div>
-      <div className="detail">
+      <StdImageContainer>
+        <img src={movie.img_url} />
+      </StdImageContainer>
+      <StdFeedDetail className="detail">
         <div className="detail-head">
           <StdProfile className="icon" src="https://i.pinimg.com/736x/a8/7e/e9/a87ee992d0b9e196edf8211bbc799521.jpg" />
           <div className="bookmark-icon" />
@@ -23,7 +23,7 @@ const DetailPage = () => {
         <div className="star">★★★</div>
         <div className="comment-list">user: 퍼가요~</div>
         <input placeholder="add a comment" />
-      </div>
+      </StdFeedDetail>
     </StdFeedContainer>
   );
 };
@@ -31,7 +31,17 @@ const DetailPage = () => {
 export default DetailPage;
 
 const StdFeedContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  max-width: 80%;
+  justify-content: center;
+  flex: 1 1 0;
   background-color: yellow;
+`;
+
+const StdFeedDetail = styled.div`
+  min-width: 50%;
+  background-color: orange;
 `;
 
 const StdProfile = styled.img`
@@ -39,6 +49,8 @@ const StdProfile = styled.img`
   background-image: cover;
 `;
 
-const StdImage = styled.img`
-  width: 50%;
+const StdImageContainer = styled.div`
+  min-width: 50%;
+  justify-items: center;
+  background-color: green;
 `;

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -1,5 +1,44 @@
+import { useLocation, useParams, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import MOCK_DATA from '../data/MOCK_DATA';
+
 const DetailPage = () => {
-  return <div>상세 페이지입니다.</div>;
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const movie = MOCK_DATA.find((p) => p.id === Number(id));
+
+  return (
+    <StdFeedContainer className="feed-container">
+      <div>
+        <StdImage src={movie.img_url} />
+      </div>
+      <div className="detail">
+        <div className="detail-head">
+          <StdProfile className="icon" src="https://i.pinimg.com/736x/a8/7e/e9/a87ee992d0b9e196edf8211bbc799521.jpg" />
+          <div className="bookmark-icon" />
+        </div>
+        <div className="hash-tag">
+          <span>#해시태그</span>
+        </div>
+        <div className="star">★★★</div>
+        <div className="comment-list">user: 퍼가요~</div>
+        <input placeholder="add a comment" />
+      </div>
+    </StdFeedContainer>
+  );
 };
 
 export default DetailPage;
+
+const StdFeedContainer = styled.div`
+  background-color: yellow;
+`;
+
+const StdProfile = styled.img`
+  width: 25px;
+  background-image: cover;
+`;
+
+const StdImage = styled.img`
+  width: 50%;
+`;

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import styled from 'styled-components';
 import MOCK_DATA from '../data/MOCK_DATA';
-import { Bookmark } from 'lucide-react';
+import { Bookmark, Heart } from 'lucide-react';
 
 const DetailPage = () => {
   const { id } = useParams();
@@ -22,6 +22,9 @@ const DetailPage = () => {
             />
             <StdBookmark>
               <Bookmark />
+            </StdBookmark>
+            <StdBookmark>
+              <Heart />
             </StdBookmark>
           </StdFeedHeader>
           <div>{movie.korean_name}</div>
@@ -95,7 +98,7 @@ const StdFeedHeader = styled.div`
   width: 100%;
   max-height: min-content;
   flex: 3 0 0;
-  gap: 20%;
+  gap: 10%;
   background-color: palegreen;
   border-bottom: dashed 2px;
 `;

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -1,30 +1,39 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import styled from 'styled-components';
 import MOCK_DATA from '../data/MOCK_DATA';
+import { Bookmark } from 'lucide-react';
 
 const DetailPage = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
   const movie = MOCK_DATA.find((p) => p.id === Number(id));
 
   return (
-    <StdFeedContainer className="feed-container">
-      <StdImageContainer>
-        <img src={movie.img_url} />
-      </StdImageContainer>
-      <StdFeedDetail className="detail">
-        <div className="detail-head">
-          <StdProfile className="icon" src="https://i.pinimg.com/736x/a8/7e/e9/a87ee992d0b9e196edf8211bbc799521.jpg" />
-          <div className="bookmark-icon" />
+    <>
+      <Link to="/main">뒤로가기</Link>
+      <StdFeedContainer className="feed-container">
+        <div>
+          <StdImageContainer>
+            <StdImage src={movie.img_url} />
+          </StdImageContainer>
+          <StdFeedDetail className="detail">
+            <div className="detail-head">
+              <StdProfile
+                className="icon"
+                src="https://i.pinimg.com/736x/a8/7e/e9/a87ee992d0b9e196edf8211bbc799521.jpg"
+              />
+              <div className="bookmark-icon" />
+              <Bookmark />
+            </div>
+            <div className="hash-tag">
+              <span>#해시태그</span>
+            </div>
+            <div className="star">★★★</div>
+            <div className="comment-list">user: 퍼가요~</div>
+            <input placeholder="add a comment" />
+          </StdFeedDetail>
         </div>
-        <div className="hash-tag">
-          <span>#해시태그</span>
-        </div>
-        <div className="star">★★★</div>
-        <div className="comment-list">user: 퍼가요~</div>
-        <input placeholder="add a comment" />
-      </StdFeedDetail>
-    </StdFeedContainer>
+      </StdFeedContainer>
+    </>
   );
 };
 
@@ -32,16 +41,20 @@ export default DetailPage;
 
 const StdFeedContainer = styled.div`
   display: flex;
-  justify-content: center;
+  text-align: center;
   max-width: 80%;
+  height: 80%;
   justify-content: center;
-  flex: 1 1 0;
+  flex: 2 1 1;
   background-color: yellow;
 `;
 
 const StdFeedDetail = styled.div`
+  margin-top: 5%;
   min-width: 50%;
+  position: sticky;
   background-color: orange;
+  border-radius: 0 5% 5% 0;
 `;
 
 const StdProfile = styled.img`
@@ -53,4 +66,7 @@ const StdImageContainer = styled.div`
   min-width: 50%;
   justify-items: center;
   background-color: green;
+  border-radius: 5% 0 0 5%;
 `;
+
+const StdImage = styled.img``;

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -9,29 +9,32 @@ const DetailPage = () => {
 
   return (
     <>
-      <Link to="/main">뒤로가기</Link>
+      <Link to="/main">뒤로가기</Link> {/*뒤로가기 아이콘 넣기*/}
       <StdFeedContainer className="feed-container">
-        <div>
-          <StdImageContainer>
-            <StdImage src={movie.img_url} />
-          </StdImageContainer>
-          <StdFeedDetail className="detail">
-            <div className="detail-head">
-              <StdProfile
-                className="icon"
-                src="https://i.pinimg.com/736x/a8/7e/e9/a87ee992d0b9e196edf8211bbc799521.jpg"
-              />
-              <div className="bookmark-icon" />
+        <StdImageContainer>
+          <StdImage src={movie.img_url} />
+        </StdImageContainer>
+        <StdFeedDetail className="detail">
+          <StdFeedHeader className="detail-head">
+            <StdProfile
+              className="icon"
+              src="https://i.pinimg.com/736x/a8/7e/e9/a87ee992d0b9e196edf8211bbc799521.jpg"
+            />
+            <StdBookmark>
               <Bookmark />
-            </div>
-            <div className="hash-tag">
-              <span>#해시태그</span>
-            </div>
-            <div className="star">★★★</div>
-            <div className="comment-list">user: 퍼가요~</div>
-            <input placeholder="add a comment" />
-          </StdFeedDetail>
-        </div>
+            </StdBookmark>
+          </StdFeedHeader>
+          <div className="hash-tag">
+            <span fontSize={'1em'}>#해시태그</span>
+          </div>
+          <div className="star">★★★</div>
+          <ul className="comment-list">
+            <li>user: 퍼가요~</li>
+            <li>user: 퍼가요~</li>
+            <li>user: 퍼가요~</li>
+          </ul>
+          <input placeholder="add a comment" />
+        </StdFeedDetail>
       </StdFeedContainer>
     </>
   );
@@ -40,33 +43,53 @@ const DetailPage = () => {
 export default DetailPage;
 
 const StdFeedContainer = styled.div`
-  display: flex;
+  display: grid;
   text-align: center;
-  max-width: 80%;
-  height: 80%;
+  grid-template-columns: repeat(2, minmax(100px, auto));
+  gap: 5%;
+  max-width: 100%;
   justify-content: center;
-  flex: 2 1 1;
   background-color: yellow;
 `;
 
 const StdFeedDetail = styled.div`
-  margin-top: 5%;
-  min-width: 50%;
-  position: sticky;
+  display: grid;
+  min-width: 40vw;
+  min-height: 50%;
+  position: relative;
   background-color: orange;
-  border-radius: 0 5% 5% 0;
+  padding: 5%;
+  border-radius: 10%;
 `;
 
 const StdProfile = styled.img`
-  width: 25px;
+  max-width: 50px;
+  max-height: 50px;
   background-image: cover;
+  border-radius: 100%;
+`;
+
+const StdBookmark = styled.div`
+  max-width: 30%;
+  max-height: 30%;
 `;
 
 const StdImageContainer = styled.div`
-  min-width: 50%;
-  justify-items: center;
+  display: flex;
+  min-width: 40vw;
+  min-height: 50%;
   background-color: green;
-  border-radius: 5% 0 0 5%;
+  border-radius: 10%;
 `;
 
-const StdImage = styled.img``;
+const StdImage = styled.img`
+  width: 100%;
+`;
+
+const StdFeedHeader = styled.div`
+  display: flex;
+  justify-content: center;
+  max-height: fit-content;
+  flex: 3 1 0;
+  gap: 20%;
+`;


### PR DESCRIPTION
### 전체적인 요약 
main 페이지 내 FeedList에서 연결, data에서 해당 id로 검색한 데이터 불러오기 
간단한 css (구획 나누기) 구현

### 상세 내용 
1. FeedList에서 각 피드마다 Link로 query-string parameter 형성 
2. datail 페이지에서 id로 data 내 일치 정보 불러오기 
3. 화면 구성 : 전체 피드 이미지 /  전체 피드 디테일과 댓글
4. 피드 이미지: image (MOCK_DATA의 img_url) 사용
5. title(MOCK_DATA의 korea_name) 과  북마크/하트/댓글 목록 (이외 더미데이터) 사용 
6. 임시 input창으로 댓글창 설정 